### PR TITLE
Save and load rotations as quanternions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.idea
 .classpath
 .settings
 bin

--- a/src/main/java/com/tom/vivecraftcompat/overlay/OverlayConfig.java
+++ b/src/main/java/com/tom/vivecraftcompat/overlay/OverlayConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Locale;
 
 import org.joml.Matrix4f;
+import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
 import net.minecraft.client.Minecraft;
@@ -31,29 +32,56 @@ public class OverlayConfig {
 			ov.setName(name);
 			ov.enable = OverlayEnable.byName(ce.getString(ConfigKeys.OVERLAY_ENABLE, ""));
 
-			for (int i = 0;i<oel.size();i++) {
+			for (int i = 0; i < oel.size(); i++) {
 				String o = String.valueOf(oel.get(i));
 				ResourceLocation id = ResourceLocation.tryParse(o);
-				if(id != null)ov.overlays.add(id);
+				if (id != null) ov.overlays.add(id);
 			}
 
 			Layer layer = new Layer(ov);
 			ov.layer = layer;
 			layer.setScale(ce.getFloat(ConfigKeys.OVERLAY_SCALE, 1));
 			layer.setLockDirect(OverlayLock.byName(ce.getString(ConfigKeys.OVERLAY_LOCK, "")));
+
 			ConfigEntry pos = ce.getEntry(ConfigKeys.OVERLAY_POS);
 			layer.setPos(new Vector3f(
 					pos.getFloat("x", 0),
 					pos.getFloat("y", 0),
 					pos.getFloat("z", 0)
-					));
+			));
+
 			ConfigEntry rot = ce.getEntry(ConfigKeys.OVERLAY_ROTATION);
-			float[] m = new float[16];
-			for(int x = 0;x<4;x++) for(int y = 0;y<4;y++) {
-				m[x * 4 + y] = rot.getFloat("m" + x + "" + y, m[x * 4 + y]);
+			// Convert Legacy Matrix4f to Quaternion if needed,
+			// does not overwrite config until save is called
+			if (rot.hasEntry("m00")) {
+				Matrix4f mat = new Matrix4f();
+				mat.m00(rot.getFloat("m00", 1));
+				mat.m01(rot.getFloat("m01", 0));
+				mat.m02(rot.getFloat("m02", 0));
+				mat.m10(rot.getFloat("m10", 0));
+				mat.m11(rot.getFloat("m11", 1));
+				mat.m12(rot.getFloat("m12", 0));
+				mat.m20(rot.getFloat("m20", 0));
+				mat.m21(rot.getFloat("m21", 0));
+				mat.m22(rot.getFloat("m22", 1));
+
+				Quaternionf quaternion = new Quaternionf();
+				mat.getUnnormalizedRotation(quaternion);
+				rot.setFloat("x", quaternion.x);
+				rot.setFloat("y", quaternion.y);
+				rot.setFloat("z", quaternion.z);
+				rot.setFloat("w", quaternion.w);
 			}
-			Matrix4f mat = new Matrix4f();
-			mat.set(m);
+			float x = rot.getFloat("x", 0);
+			float y = rot.getFloat("y", 0);
+			float z = rot.getFloat("z", 0);
+			float w = rot.getFloat("w", 1);  // Default w to 1 for identity quaternion
+
+			Quaternionf quaternion = new Quaternionf(x, y, z, w);
+
+			// Convert the quaternion to a matrix, since the overlay system uses matrices for rotation
+			Matrix4f mat = new Matrix4f().rotate(quaternion);
+
 			layer.setRotation(mat);
 
 			loadedLayers.add(layer);
@@ -61,6 +89,7 @@ public class OverlayConfig {
 
 		Minecraft.getInstance().execute(() -> loadedLayers.forEach(OverlayManager::addLayer));
 	}
+
 
 	public static void saveOverlays() {
 		ConfigEntryTemp config = Client.config.createTemp();
@@ -82,14 +111,20 @@ public class OverlayConfig {
 				pos.setFloat("x", p.x);
 				pos.setFloat("y", p.y);
 				pos.setFloat("z", p.z);
+
+				// Rotation handling using Quaternion (float4)
 				ConfigEntry rot = ce.getEntry(ConfigKeys.OVERLAY_ROTATION);
-				Matrix4f r = l.getRotationRaw();
-				float[] m = r.get(new float[16]);
-				for(int x = 0;x<4;x++) for(int y = 0;y<4;y++) {
-					rot.setFloat("m" + x + "" + y, m[x * 4 + y]);
-				}
+				Matrix4f rotationMatrix = l.getRotationRaw();
+				Quaternionf quaternion = new Quaternionf();
+				rotationMatrix.getUnnormalizedRotation(quaternion);
+
+				rot.setFloat("x", quaternion.x);
+				rot.setFloat("y", quaternion.y);
+				rot.setFloat("z", quaternion.z);
+				rot.setFloat("w", quaternion.w);
 			}
 		});
 		config.saveConfig();
 	}
+
 }


### PR DESCRIPTION
This just makes the rotation stored in the configs save as a Quanternion, rather than a float16/matrix4f, 

this makes it so config files are both smaller and easier to modify by hand for those of us who have issues with seeing when things arnt perfectly level, as the current "in game" config screen leaves a few things to be desired at the moment (primarily, a better way to trigger the repositioning of the UI that isnt as tedius)

An example of the configuration change is the following json, first is the config currently in my modpack for jade, 
Second is the config after using this patch and moving it *slightly* to the left to trigger a re-save of the config


```json
{
  "elements": {
    "647f7441-4d42-40ae-a969-2288161166c9": {
      "pos": {
        "x": -0.008788988,
        "y": 0.0029975772,
        "z": 0.15286042
      },
      "enable": "always",
      "rotation": {
        "m20": -0.05482076,
        "m31": 0.0,
        "m30": 0.0,
        "m00": 0.9982965,
        "m11": 0.76774055,
        "m22": 0.76603323,
        "m33": 1.0,
        "m10": 0.020146132,
        "m21": 0.6404616,
        "m32": 0.0,
        "m02": 0.054991186,
        "m13": 0.0,
        "m01": 0.019676581,
        "m12": -0.6404481,
        "m23": 0.0,
        "m03": 0.0
      },
      "elements": [
        "vivecraftcompat:jade"
      ],
      "name": "RightController - Jade",
      "lock": "right_hand",
      "scale": 0.3
    }
  }
}
```

```json
{
  "elements": {
    "647f7441-4d42-40ae-a969-2288161166c9": {
      "pos": {
        "x": -0.020143274,
        "y": 0.0053924737,
        "z": 0.15690143
      },
      "enable": "always",
      "rotation": {
        "w": 0.947243,
        "x": -0.32006064,
        "y": -0.015925813,
        "z": -0.00618945
      },
      "elements": [
        "vivecraftcompat:jade"
      ],
      "name": "RightController - Jade",
      "lock": "right_hand",
      "scale": 0.3
    }
  }
}
```